### PR TITLE
feat: support for write-only attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-openapi/swag v0.23.1
 	github.com/go-openapi/validate v0.24.0
+	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-framework v1.15.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-go v0.28.0
@@ -43,7 +44,6 @@ require (
 	github.com/hashicorp/go-plugin v1.6.3 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
-	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/hc-install v0.9.2 // indirect
 	github.com/hashicorp/hcl/v2 v2.23.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect

--- a/internal/provider/project_key_data_source_test.go
+++ b/internal/provider/project_key_data_source_test.go
@@ -75,7 +75,7 @@ func TestAcc_ProjectKeyDataSource_basicName(t *testing.T) {
 				Config: testAccProjectKeyDataSourceConfigByName(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.semaphoreui_project_key.test", "name", "Password"),
-					resource.TestCheckResourceAttr("data.semaphoreui_project_key.test", "login_password.%", "2"),
+					resource.TestCheckResourceAttr("data.semaphoreui_project_key.test", "login_password.%", "4"),
 					resource.TestCheckResourceAttr("data.semaphoreui_project_key.test", "login_password.password", ""),
 					resource.TestCheckNoResourceAttr("data.semaphoreui_project_key.test", "none"),
 					resource.TestCheckNoResourceAttr("data.semaphoreui_project_key.test", "ssh"),

--- a/internal/provider/project_key_resource.go
+++ b/internal/provider/project_key_resource.go
@@ -76,9 +76,18 @@ func convertProjectKeyModelToAccessKeyRequest(key, config ProjectKeyModel) *mode
 		model.Type = ProjectKeyTypeNone
 	} else if key.LoginPassword != nil {
 		model.Type = ProjectKeyTypeLoginPassword
+
+		// Determine which password to use
+		var password string
+		if !config.LoginPassword.PasswordWO.IsNull() {
+			password = config.LoginPassword.PasswordWO.ValueString()
+		} else {
+			password = key.LoginPassword.Password.ValueString()
+		}
+
 		model.LoginPassword = &models.AccessKeyRequestLoginPassword{
 			Login:    key.LoginPassword.Login.ValueString(),
-			Password: key.LoginPassword.Password.ValueString(),
+			Password: password,
 		}
 	} else if key.SSH != nil {
 		model.Type = ProjectKeyTypeSSH
@@ -228,9 +237,12 @@ func (r *projectKeyResource) Update(ctx context.Context, req resource.UpdateRequ
 		// Key type has not changed, so we need to check if individual fields have changed
 		switch plan.Type().ValueString() {
 		case ProjectKeyTypeLoginPassword:
+			versionChanged := !plan.LoginPassword.PasswordWOVersion.Equal(state.LoginPassword.PasswordWOVersion)
+
 			if !plan.LoginPassword.Login.Equal(state.LoginPassword.Login) ||
 				!plan.LoginPassword.Password.Equal(state.LoginPassword.Password) ||
-				!plan.Name.Equal(state.Name) {
+				!plan.Name.Equal(state.Name) ||
+				versionChanged {
 				key.OverrideSecret = true
 			} else {
 				// Use empty struct when secrets haven't changed

--- a/internal/provider/project_key_resource.go
+++ b/internal/provider/project_key_resource.go
@@ -81,10 +81,19 @@ func convertProjectKeyModelToAccessKeyRequest(key ProjectKeyModel) *models.Acces
 		}
 	} else if key.SSH != nil {
 		model.Type = ProjectKeyTypeSSH
+
+		// Determine which private key to use
+		var privateKey string
+		if !key.SSH.PrivateKeyWO.IsNull() && !key.SSH.PrivateKeyWO.IsUnknown() {
+			privateKey = key.SSH.PrivateKeyWO.ValueString()
+		} else {
+			privateKey = key.SSH.PrivateKey.ValueString()
+		}
+
 		model.SSH = &models.AccessKeyRequestSSH{
 			Login:      key.SSH.Login.ValueString(),
 			Passphrase: key.SSH.Passphrase.ValueString(),
-			PrivateKey: key.SSH.PrivateKey.ValueString(),
+			PrivateKey: privateKey,
 		}
 	}
 
@@ -226,11 +235,15 @@ func (r *projectKeyResource) Update(ctx context.Context, req resource.UpdateRequ
 				key.LoginPassword = &models.AccessKeyRequestLoginPassword{}
 			}
 		case ProjectKeyTypeSSH:
+			versionChanged := !plan.SSH.PrivateKeyWOVersion.Equal(state.SSH.PrivateKeyWOVersion)
+
 			if !plan.SSH.Login.Equal(state.SSH.Login) ||
 				!plan.SSH.Passphrase.Equal(state.SSH.Passphrase) ||
 				!plan.SSH.PrivateKey.Equal(state.SSH.PrivateKey) ||
-				!plan.Name.Equal(state.Name) {
+				!plan.Name.Equal(state.Name) ||
+				versionChanged {
 				key.OverrideSecret = true
+
 			} else {
 				// Use empty struct when secrets haven't changed
 				key.SSH = &models.AccessKeyRequestSSH{}

--- a/internal/provider/project_key_resource.go
+++ b/internal/provider/project_key_resource.go
@@ -3,13 +3,14 @@ package provider
 import (
 	"context"
 	"fmt"
+	apiclient "terraform-provider-semaphoreui/semaphoreui/client"
+	"terraform-provider-semaphoreui/semaphoreui/client/project"
+	"terraform-provider-semaphoreui/semaphoreui/models"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	apiclient "terraform-provider-semaphoreui/semaphoreui/client"
-	"terraform-provider-semaphoreui/semaphoreui/client/project"
-	"terraform-provider-semaphoreui/semaphoreui/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -63,7 +64,7 @@ func (r *projectKeyResource) ConfigValidators(ctx context.Context) []resource.Co
 	}
 }
 
-func convertProjectKeyModelToAccessKeyRequest(key ProjectKeyModel) *models.AccessKeyRequest {
+func convertProjectKeyModelToAccessKeyRequest(key, config ProjectKeyModel) *models.AccessKeyRequest {
 	model := models.AccessKeyRequest{
 		ProjectID: key.ProjectID.ValueInt64(),
 		Name:      key.Name.ValueString(),
@@ -84,8 +85,8 @@ func convertProjectKeyModelToAccessKeyRequest(key ProjectKeyModel) *models.Acces
 
 		// Determine which private key to use
 		var privateKey string
-		if !key.SSH.PrivateKeyWO.IsNull() && !key.SSH.PrivateKeyWO.IsUnknown() {
-			privateKey = key.SSH.PrivateKeyWO.ValueString()
+		if !config.SSH.PrivateKeyWO.IsNull() && !config.SSH.PrivateKeyWO.IsUnknown() {
+			privateKey = config.SSH.PrivateKeyWO.ValueString()
 		} else {
 			privateKey = key.SSH.PrivateKey.ValueString()
 		}
@@ -151,16 +152,16 @@ func (r *projectKeyResource) getProjectKeyModelFromClient(projectId types.Int64,
 
 func (r *projectKeyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// Retrieve values from plan
-	var plan ProjectKeyModel
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	var plan, config ProjectKeyModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	response, err := r.client.Project.PostProjectProjectIDKeys(&project.PostProjectProjectIDKeysParams{
 		ProjectID: plan.ProjectID.ValueInt64(),
-		AccessKey: convertProjectKeyModelToAccessKeyRequest(plan),
+		AccessKey: convertProjectKeyModelToAccessKeyRequest(plan, config),
 	}, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -172,7 +173,7 @@ func (r *projectKeyResource) Create(ctx context.Context, req resource.CreateRequ
 	plan = convertAccessKeyResponseToProjectKeyModel(response.Payload, &plan)
 
 	// Set state to fully populated data
-	diags = resp.State.Set(ctx, &plan)
+	diags := resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -209,15 +210,16 @@ func (r *projectKeyResource) Read(ctx context.Context, req resource.ReadRequest,
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *projectKeyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	// Retrieve values from plan and state
-	var plan, state ProjectKeyModel
+	var plan, config, state ProjectKeyModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	// Create an access key based on the plan
-	key := convertProjectKeyModelToAccessKeyRequest(plan)
+	key := convertProjectKeyModelToAccessKeyRequest(plan, config)
 	// Check if type of key has changed
 	if !plan.Type().Equal(state.Type()) {
 		// If key type has changed, we must update the secrets

--- a/internal/provider/project_key_resource.go
+++ b/internal/provider/project_key_resource.go
@@ -100,9 +100,17 @@ func convertProjectKeyModelToAccessKeyRequest(key, config ProjectKeyModel) *mode
 			privateKey = key.SSH.PrivateKey.ValueString()
 		}
 
+		// Determine which passphrase to use
+		var passphrase string
+		if !config.SSH.PassphraseWO.IsNull() {
+			passphrase = config.SSH.PassphraseWO.ValueString()
+		} else {
+			passphrase = key.SSH.Passphrase.ValueString()
+		}
+
 		model.SSH = &models.AccessKeyRequestSSH{
 			Login:      key.SSH.Login.ValueString(),
-			Passphrase: key.SSH.Passphrase.ValueString(),
+			Passphrase: passphrase,
 			PrivateKey: privateKey,
 		}
 	}
@@ -249,13 +257,15 @@ func (r *projectKeyResource) Update(ctx context.Context, req resource.UpdateRequ
 				key.LoginPassword = &models.AccessKeyRequestLoginPassword{}
 			}
 		case ProjectKeyTypeSSH:
-			versionChanged := !plan.SSH.PrivateKeyWOVersion.Equal(state.SSH.PrivateKeyWOVersion)
+			privateKeyVersionChanged := !plan.SSH.PrivateKeyWOVersion.Equal(state.SSH.PrivateKeyWOVersion)
+			passphraseVersionChanged := !plan.SSH.PassphraseWOVersion.Equal(state.SSH.PassphraseWOVersion)
 
 			if !plan.SSH.Login.Equal(state.SSH.Login) ||
 				!plan.SSH.Passphrase.Equal(state.SSH.Passphrase) ||
 				!plan.SSH.PrivateKey.Equal(state.SSH.PrivateKey) ||
 				!plan.Name.Equal(state.Name) ||
-				versionChanged {
+				privateKeyVersionChanged ||
+				passphraseVersionChanged {
 				key.OverrideSecret = true
 
 			} else {

--- a/internal/provider/project_key_resource.go
+++ b/internal/provider/project_key_resource.go
@@ -85,7 +85,7 @@ func convertProjectKeyModelToAccessKeyRequest(key, config ProjectKeyModel) *mode
 
 		// Determine which private key to use
 		var privateKey string
-		if !config.SSH.PrivateKeyWO.IsNull() && !config.SSH.PrivateKeyWO.IsUnknown() {
+		if !config.SSH.PrivateKeyWO.IsNull() {
 			privateKey = config.SSH.PrivateKeyWO.ValueString()
 		} else {
 			privateKey = key.SSH.PrivateKey.ValueString()

--- a/internal/provider/project_key_resource_test.go
+++ b/internal/provider/project_key_resource_test.go
@@ -106,6 +106,16 @@ func testAccProjectKeySSHConfigWo(nameSuffix string, login string, privateKey st
 }`, login, version, privateKey, passphrase))
 }
 
+func testAccProjectKeySSHConfigPassphraseWo(nameSuffix string, login string, privateKey string, passphrase string, version int) string {
+	return testAccProjectKeyConfig(nameSuffix, fmt.Sprintf(`ssh = {
+  login       = "%[1]s"
+  private_key = <<-EOT
+%[2]sEOT
+  passphrase_wo         = "%[3]s"
+  passphrase_wo_version = %[4]d
+}`, login, privateKey, passphrase, version))
+}
+
 func testAccProjectKeyImportID(n string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[n]
@@ -226,7 +236,7 @@ func TestAcc_ProjectKeyResource_basicSSH(t *testing.T) {
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "login_password"),
-					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.%", "5"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.%", "7"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.login", "username"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.private_key", privateKey),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.passphrase", "passphrase"),
@@ -254,7 +264,7 @@ func TestAcc_ProjectKeyResource_basicSSH(t *testing.T) {
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "login_password"),
-					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.%", "5"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.%", "7"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.login", "testing"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.private_key", privateKey),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.passphrase", ""),
@@ -336,10 +346,50 @@ func TestAcc_ProjectKeyResource_changeType(t *testing.T) {
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "login_password"),
-					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.%", "5"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.%", "7"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.login", "username"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.private_key", privateKey),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.passphrase", ""),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_key.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_ProjectKeyResource_passphraseWo(t *testing.T) {
+	nameSuffix := acctest.RandString(8)
+	_, privateKey, _ := acctest.RandSSHKeyPair("")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccProjectKeySSHConfigPassphraseWo(nameSuffix, "username", privateKey, "secret", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectKeyExists("semaphoreui_project_key.test", ProjectKeyTypeSSH),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.passphrase_wo_version", "1"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh.passphrase_wo"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh.passphrase"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_key.test", "id"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: testAccProjectKeySSHConfigPassphraseWo(nameSuffix, "username", privateKey, "updated", 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectKeyExists("semaphoreui_project_key.test", ProjectKeyTypeSSH),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.passphrase_wo_version", "2"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh.passphrase_wo"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh.passphrase"),
 					resource.TestCheckResourceAttrSet("semaphoreui_project_key.test", "id"),
 				),
 			},

--- a/internal/provider/project_key_resource_test.go
+++ b/internal/provider/project_key_resource_test.go
@@ -6,8 +6,10 @@ import (
 	"terraform-provider-semaphoreui/semaphoreui/client/project"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -340,9 +342,13 @@ func TestAcc_ProjectKeyResource_changeType(t *testing.T) {
 func TestAcc_ProjectKeyResource_privateKeyWo(t *testing.T) {
 	nameSuffix := acctest.RandString(8)
 	_, privateKey, _ := acctest.RandSSHKeyPair("")
+	_, updatedKey, _ := acctest.RandSSHKeyPair("")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -359,7 +365,7 @@ func TestAcc_ProjectKeyResource_privateKeyWo(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccProjectKeySSHConfigWo(nameSuffix, "username", privateKey, "", 2),
+				Config: testAccProjectKeySSHConfigWo(nameSuffix, "username", updatedKey, "", 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccProjectKeyExists("semaphoreui_project_key.test", ProjectKeyTypeSSH),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),

--- a/internal/provider/project_key_resource_test.go
+++ b/internal/provider/project_key_resource_test.go
@@ -2,11 +2,12 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"strconv"
 	"terraform-provider-semaphoreui/semaphoreui/client/project"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -83,6 +84,16 @@ func testAccProjectKeySSHConfig(nameSuffix string, login string, privateKey stri
 %[2]sEOT
   passphrase = "%[3]s"
 }`, login, privateKey, passphrase))
+}
+
+func testAccProjectKeySSHConfigWo(nameSuffix string, login string, privateKey string, passphrase string, version int) string {
+	return testAccProjectKeyConfig(nameSuffix, fmt.Sprintf(`ssh = {
+  login       = "%[1]s"
+  private_key_wo_version = %[2]d
+  private_key_wo = <<-EOT
+%[3]sEOT
+  passphrase = "%[4]s"
+}`, login, version, privateKey, passphrase))
 }
 
 func testAccProjectKeyImportID(n string) resource.ImportStateIdFunc {
@@ -205,7 +216,7 @@ func TestAcc_ProjectKeyResource_basicSSH(t *testing.T) {
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "login_password"),
-					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.%", "3"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.%", "5"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.login", "username"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.private_key", privateKey),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.passphrase", "passphrase"),
@@ -233,7 +244,7 @@ func TestAcc_ProjectKeyResource_basicSSH(t *testing.T) {
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "login_password"),
-					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.%", "3"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.%", "5"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.login", "testing"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.private_key", privateKey),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.passphrase", ""),
@@ -315,10 +326,47 @@ func TestAcc_ProjectKeyResource_changeType(t *testing.T) {
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "login_password"),
-					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.%", "3"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.%", "5"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.login", "username"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.private_key", privateKey),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.passphrase", ""),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_key.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_ProjectKeyResource_privateKeyWo(t *testing.T) {
+	nameSuffix := acctest.RandString(8)
+	_, privateKey, _ := acctest.RandSSHKeyPair("")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccProjectKeySSHConfigWo(nameSuffix, "username", privateKey, "", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectKeyExists("semaphoreui_project_key.test", ProjectKeyTypeSSH),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.private_key_wo_version", "1"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh.private_key_wo"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh.private_key"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_key.test", "id"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: testAccProjectKeySSHConfigWo(nameSuffix, "username", privateKey, "", 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectKeyExists("semaphoreui_project_key.test", ProjectKeyTypeSSH),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.private_key_wo_version", "2"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh.private_key_wo"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh.private_key"),
 					resource.TestCheckResourceAttrSet("semaphoreui_project_key.test", "id"),
 				),
 			},

--- a/internal/provider/project_key_resource_test.go
+++ b/internal/provider/project_key_resource_test.go
@@ -79,6 +79,14 @@ func testAccProjectKeyLoginPasswordConfig(nameSuffix string, login string, passw
 }`, login, password))
 }
 
+func testAccProjectKeyLoginPasswordConfigWo(nameSuffix string, login string, password string, version int) string {
+	return testAccProjectKeyConfig(nameSuffix, fmt.Sprintf(`login_password = {
+  login              = "%[1]s"
+  password_wo        = "%[2]s"
+  password_wo_version = %[3]d
+}`, login, password, version))
+}
+
 func testAccProjectKeySSHConfig(nameSuffix string, login string, privateKey string, passphrase string) string {
 	return testAccProjectKeyConfig(nameSuffix, fmt.Sprintf(`ssh = {
   login       = "%[1]s"
@@ -158,7 +166,7 @@ func TestAcc_ProjectKeyResource_basicLoginPassword(t *testing.T) {
 					testAccProjectKeyExists("semaphoreui_project_key.test", ProjectKeyTypeLoginPassword),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
-					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.%", "2"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.%", "4"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.login", "username"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.password", "password"),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh"),
@@ -185,7 +193,7 @@ func TestAcc_ProjectKeyResource_basicLoginPassword(t *testing.T) {
 					testAccProjectKeyExists("semaphoreui_project_key.test", ProjectKeyTypeLoginPassword),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
-					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.%", "2"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.%", "4"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.login", "foo"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.password", "bar"),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh"),
@@ -313,7 +321,7 @@ func TestAcc_ProjectKeyResource_changeType(t *testing.T) {
 					testAccProjectKeyExists("semaphoreui_project_key.test", ProjectKeyTypeLoginPassword),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
-					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.%", "2"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.%", "4"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.login", "username"),
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.password", "password"),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh"),
@@ -373,6 +381,45 @@ func TestAcc_ProjectKeyResource_privateKeyWo(t *testing.T) {
 					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "ssh.private_key_wo_version", "2"),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh.private_key_wo"),
 					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "ssh.private_key"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_key.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_ProjectKeyResource_passwordWo(t *testing.T) {
+	nameSuffix := acctest.RandString(8)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccProjectKeyLoginPasswordConfigWo(nameSuffix, "username", "secret", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectKeyExists("semaphoreui_project_key.test", ProjectKeyTypeLoginPassword),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.password_wo_version", "1"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "login_password.password_wo"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "login_password.password"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_key.test", "id"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: testAccProjectKeyLoginPasswordConfigWo(nameSuffix, "username", "updated", 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectKeyExists("semaphoreui_project_key.test", ProjectKeyTypeLoginPassword),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "none"),
+					resource.TestCheckResourceAttr("semaphoreui_project_key.test", "login_password.password_wo_version", "2"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "login_password.password_wo"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_key.test", "login_password.password"),
 					resource.TestCheckResourceAttrSet("semaphoreui_project_key.test", "id"),
 				),
 			},

--- a/internal/provider/project_key_schema.go
+++ b/internal/provider/project_key_schema.go
@@ -212,6 +212,9 @@ func ProjectKeySchema() superschema.Schema {
 						Common: &schemaR.Int64Attribute{
 							Optional:    true,
 							Description: "Version tracker to trigger updates for the write-only attribute.",
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.RequiresReplace(),
+							},
 						},
 					},
 				},

--- a/internal/provider/project_key_schema.go
+++ b/internal/provider/project_key_schema.go
@@ -194,6 +194,26 @@ func ProjectKeySchema() superschema.Schema {
 							Computed: true,
 						},
 					},
+					"private_key_wo": superschema.StringAttribute{
+						Common: &schemaR.StringAttribute{
+							MarkdownDescription: "The SSH private key.",
+							Sensitive:           true,
+							WriteOnly:           true,
+							Description:         "Write-only version of the private key for ephemeral compatibility.",
+						},
+						Resource: &schemaR.StringAttribute{
+							Optional: true,
+						},
+						DataSource: &schemaD.StringAttribute{
+							Computed: true,
+						},
+					},
+					"private_key_wo_version": superschema.Int64Attribute{
+						Common: &schemaR.Int64Attribute{
+							Optional:    true,
+							Description: "Version tracker to trigger updates for the write-only attribute.",
+						},
+					},
 				},
 			},
 			ProjectKeyTypeNone: superschema.SingleNestedAttribute{

--- a/internal/provider/project_key_schema.go
+++ b/internal/provider/project_key_schema.go
@@ -33,6 +33,8 @@ type (
 	ProjectKeySSH struct {
 		Login               types.String `tfsdk:"login"`
 		Passphrase          types.String `tfsdk:"passphrase"`
+		PassphraseWO        types.String `tfsdk:"passphrase_wo"`
+		PassphraseWOVersion types.Int64  `tfsdk:"passphrase_wo_version"`
 		PrivateKey          types.String `tfsdk:"private_key"`
 		PrivateKeyWO        types.String `tfsdk:"private_key_wo"`
 		PrivateKeyWOVersion types.Int64  `tfsdk:"private_key_wo_version"`
@@ -221,8 +223,44 @@ func ProjectKeySchema() superschema.Schema {
 						},
 						Resource: &schemaR.StringAttribute{
 							Optional: true,
+							Validators: []validator.String{
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("passphrase_wo")),
+							},
 						},
 						DataSource: &schemaD.StringAttribute{
+							Computed: true,
+						},
+					},
+					"passphrase_wo": superschema.StringAttribute{
+						Common: &schemaR.StringAttribute{
+							MarkdownDescription: "The SSH Key passphrase.",
+							Sensitive:           true,
+							WriteOnly:           true,
+							Description:         "Write-only version of the passphrase for ephemeral compatibility.",
+						},
+						Resource: &schemaR.StringAttribute{
+							Optional: true,
+							Validators: []validator.String{
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("passphrase")),
+								stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("passphrase_wo_version")),
+							},
+						},
+						DataSource: &schemaD.StringAttribute{
+							Computed: true,
+						},
+					},
+					"passphrase_wo_version": superschema.Int64Attribute{
+						Common: &schemaR.Int64Attribute{
+							Optional:    true,
+							Description: "Version tracker to trigger updates for the write-only attribute.",
+						},
+						Resource: &schemaR.Int64Attribute{
+							Optional: true,
+							Validators: []validator.Int64{
+								int64validator.AlsoRequires(path.MatchRelative().AtParent().AtName("passphrase_wo")),
+							},
+						},
+						DataSource: &schemaD.Int64Attribute{
 							Computed: true,
 						},
 					},

--- a/internal/provider/project_key_schema.go
+++ b/internal/provider/project_key_schema.go
@@ -29,9 +29,11 @@ type (
 	}
 
 	ProjectKeySSH struct {
-		Login      types.String `tfsdk:"login"`
-		Passphrase types.String `tfsdk:"passphrase"`
-		PrivateKey types.String `tfsdk:"private_key"`
+		Login               types.String `tfsdk:"login"`
+		Passphrase          types.String `tfsdk:"passphrase"`
+		PrivateKey          types.String `tfsdk:"private_key"`
+		PrivateKeyWO        types.String `tfsdk:"private_key_wo"`
+		PrivateKeyWOVersion types.Int64  `tfsdk:"private_key_wo_version"`
 	}
 
 	ProjectKeyNone struct{}

--- a/internal/provider/project_key_schema.go
+++ b/internal/provider/project_key_schema.go
@@ -180,7 +180,7 @@ func ProjectKeySchema() superschema.Schema {
 					"password_wo_version": superschema.Int64Attribute{
 						Common: &schemaR.Int64Attribute{
 							Optional:    true,
-							Description: "Version tracker to trigger updates for the write-only attribute.",
+							Description: "Version tracker to trigger updates for the write-only password attribute.",
 						},
 						Resource: &schemaR.Int64Attribute{
 							Optional: true,
@@ -252,7 +252,7 @@ func ProjectKeySchema() superschema.Schema {
 					"passphrase_wo_version": superschema.Int64Attribute{
 						Common: &schemaR.Int64Attribute{
 							Optional:    true,
-							Description: "Version tracker to trigger updates for the write-only attribute.",
+							Description: "Version tracker to trigger updates for the write-only passphrase attribute.",
 						},
 						Resource: &schemaR.Int64Attribute{
 							Optional: true,
@@ -300,7 +300,7 @@ func ProjectKeySchema() superschema.Schema {
 					"private_key_wo_version": superschema.Int64Attribute{
 						Common: &schemaR.Int64Attribute{
 							Optional:    true,
-							Description: "Version tracker to trigger updates for the write-only attribute.",
+							Description: "Version tracker to trigger updates for the write-only private key attribute.",
 						},
 						Resource: &schemaR.Int64Attribute{
 							Optional: true,

--- a/internal/provider/project_key_schema.go
+++ b/internal/provider/project_key_schema.go
@@ -191,6 +191,9 @@ func ProjectKeySchema() superschema.Schema {
 						},
 						Resource: &schemaR.StringAttribute{
 							Optional: true,
+							Validators: []validator.String{
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("private_key_wo")),
+							},
 						},
 						DataSource: &schemaD.StringAttribute{
 							Computed: true,
@@ -205,6 +208,10 @@ func ProjectKeySchema() superschema.Schema {
 						},
 						Resource: &schemaR.StringAttribute{
 							Optional: true,
+							Validators: []validator.String{
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("private_key")),
+								stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("private_key_wo_version")),
+							},
 						},
 						DataSource: &schemaD.StringAttribute{
 							Computed: true,
@@ -214,9 +221,15 @@ func ProjectKeySchema() superschema.Schema {
 						Common: &schemaR.Int64Attribute{
 							Optional:    true,
 							Description: "Version tracker to trigger updates for the write-only attribute.",
-							PlanModifiers: []planmodifier.Int64{
-								int64planmodifier.RequiresReplace(),
+						},
+						Resource: &schemaR.Int64Attribute{
+							Optional: true,
+							Validators: []validator.Int64{
+								int64validator.AlsoRequires(path.MatchRelative().AtParent().AtName("private_key_wo")),
 							},
+						},
+						DataSource: &schemaD.Int64Attribute{
+							Computed: true,
 						},
 					},
 				},

--- a/internal/provider/project_key_schema.go
+++ b/internal/provider/project_key_schema.go
@@ -24,8 +24,10 @@ type (
 	}
 
 	ProjectKeyLoginPassword struct {
-		Login    types.String `tfsdk:"login"`
-		Password types.String `tfsdk:"password"`
+		Login             types.String `tfsdk:"login"`
+		Password          types.String `tfsdk:"password"`
+		PasswordWO        types.String `tfsdk:"password_wo"`
+		PasswordWOVersion types.Int64  `tfsdk:"password_wo_version"`
 	}
 
 	ProjectKeySSH struct {
@@ -142,9 +144,49 @@ func ProjectKeySchema() superschema.Schema {
 							Sensitive:           true,
 						},
 						Resource: &schemaR.StringAttribute{
-							Required: true,
+							Optional: true,
+							Validators: []validator.String{
+								stringvalidator.ExactlyOneOf(
+									path.MatchRelative().AtParent().AtName("password"),
+									path.MatchRelative().AtParent().AtName("password_wo")),
+							},
 						},
 						DataSource: &schemaD.StringAttribute{
+							Computed: true,
+						},
+					},
+					"password_wo": superschema.StringAttribute{
+						Common: &schemaR.StringAttribute{
+							MarkdownDescription: "The login password.",
+							Sensitive:           true,
+							WriteOnly:           true,
+							Description:         "Write-only version of the password for ephemeral compatibility.",
+						},
+						Resource: &schemaR.StringAttribute{
+							Optional: true,
+							Validators: []validator.String{
+								stringvalidator.ExactlyOneOf(
+									path.MatchRelative().AtParent().AtName("password"),
+									path.MatchRelative().AtParent().AtName("password_wo")),
+								stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("password_wo_version")),
+							},
+						},
+						DataSource: &schemaD.StringAttribute{
+							Computed: true,
+						},
+					},
+					"password_wo_version": superschema.Int64Attribute{
+						Common: &schemaR.Int64Attribute{
+							Optional:    true,
+							Description: "Version tracker to trigger updates for the write-only attribute.",
+						},
+						Resource: &schemaR.Int64Attribute{
+							Optional: true,
+							Validators: []validator.Int64{
+								int64validator.AlsoRequires(path.MatchRelative().AtParent().AtName("password_wo")),
+							},
+						},
+						DataSource: &schemaD.Int64Attribute{
 							Computed: true,
 						},
 					},

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -3,13 +3,14 @@ package provider
 import (
 	"context"
 	"fmt"
+	apiclient "terraform-provider-semaphoreui/semaphoreui/client"
+	"terraform-provider-semaphoreui/semaphoreui/client/user"
+	"terraform-provider-semaphoreui/semaphoreui/models"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	apiclient "terraform-provider-semaphoreui/semaphoreui/client"
-	"terraform-provider-semaphoreui/semaphoreui/client/user"
-	"terraform-provider-semaphoreui/semaphoreui/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -63,16 +64,25 @@ func convertResponsePayloadToUserModel(user *models.User, prev UserModel) UserMo
 		External: types.BoolValue(user.External),
 		Alert:    types.BoolValue(user.Alert),
 		// Password is not returned by the API so we use previously set password
-		Password: prev.Password,
+		Password:          prev.Password,
+		PasswordWOVersion: prev.PasswordWOVersion,
 	}
 }
 
-func convertUserModelToUserRequest(user UserModel) *models.UserRequest {
+func convertUserModelToUserRequest(user, config UserModel) *models.UserRequest {
+	// Determine which password to use
+	var password string
+	if !config.PasswordWO.IsNull() {
+		password = config.PasswordWO.ValueString()
+	} else {
+		password = user.Password.ValueString()
+	}
+
 	return &models.UserRequest{
 		Username: user.Username.ValueString(),
 		Name:     user.Name.ValueString(),
 		Email:    user.Email.ValueString(),
-		Password: strfmt.Password(user.Password.ValueString()),
+		Password: strfmt.Password(password),
 		Admin:    user.Admin.ValueBool(),
 		Alert:    user.Alert.ValueBool(),
 		External: user.External.ValueBool(),
@@ -91,15 +101,15 @@ func convertUserModelToUserPutRequest(user UserModel) *models.UserPutRequest {
 
 func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// Retrieve values from plan
-	var plan UserModel
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	var plan, config UserModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	// Generate API request body from plan
-	var payload = convertUserModelToUserRequest(plan)
+	var payload = convertUserModelToUserRequest(plan, config)
 
 	//Create new user
 	response, err := r.client.User.PostUsers(&user.PostUsersParams{User: payload}, nil)
@@ -115,8 +125,7 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 	plan = convertResponsePayloadToUserModel(response.Payload, plan)
 
 	// Set state to fully populated data
-	diags = resp.State.Set(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -156,9 +165,10 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	// Retrieve values from plan
-	var plan UserModel
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	var plan, config, state UserModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -176,11 +186,18 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	// Determine which password to use
+	var password string
+	if !config.PasswordWO.IsNull() {
+		password = config.PasswordWO.ValueString()
+	} else {
+		password = plan.Password.ValueString()
+	}
+
 	// Update password if it's changed
-	var prevPassword types.String
-	req.State.GetAttribute(ctx, path.Root("password"), &prevPassword)
-	if plan.Password != prevPassword {
-		_, err := r.client.User.PostUsersUserIDPassword(&user.PostUsersUserIDPasswordParams{UserID: plan.ID.ValueInt64(), Password: user.PostUsersUserIDPasswordBody{Password: strfmt.Password(plan.Password.ValueString())}}, nil)
+	passwordVersionChanged := !plan.PasswordWOVersion.Equal(state.PasswordWOVersion)
+	if plan.Password != state.Password || passwordVersionChanged {
+		_, err := r.client.User.PostUsersUserIDPassword(&user.PostUsersUserIDPasswordParams{UserID: plan.ID.ValueInt64(), Password: user.PostUsersUserIDPasswordBody{Password: strfmt.Password(password)}}, nil)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Updating Semaphore User Password",
@@ -202,8 +219,7 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	// Update resource state with updated user
 	plan = convertResponsePayloadToUserModel(response.Payload, plan)
 
-	diags = resp.State.Set(ctx, plan)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -2,14 +2,16 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"regexp"
 	"strconv"
 	"terraform-provider-semaphoreui/semaphoreui/client/user"
 	"testing"
 
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func testAccUserExists(resourceName string) resource.TestCheckFunc {
@@ -134,6 +136,48 @@ func TestAcc_UserResource_errorOnExists(t *testing.T) {
 			{
 				Config:      testAccUserConfig_Exists(userNameSuffix),
 				ExpectError: regexp.MustCompile("Could not create user, unexpected error"),
+			},
+		},
+	})
+}
+
+func TestAcc_UserResource_passwordWo(t *testing.T) {
+	userNameSuffix := acctest.RandString(8)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccUserConfig(userNameSuffix, `  admin = true
+  password_wo = "password!"
+  password_wo_version = 1`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccUserExists("semaphoreui_user.test"),
+					resource.TestCheckResourceAttr("semaphoreui_user.test", "username", fmt.Sprintf("test-%s", userNameSuffix)),
+					resource.TestCheckResourceAttr("semaphoreui_user.test", "password_wo_version", "1"),
+					resource.TestCheckNoResourceAttr("semaphoreui_user.test", "password_wo"),
+					resource.TestCheckNoResourceAttr("semaphoreui_user.test", "password"),
+					resource.TestCheckResourceAttrSet("semaphoreui_user.test", "id"),
+					resource.TestCheckResourceAttrSet("semaphoreui_user.test", "created"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: testAccUserConfig(userNameSuffix, `  admin = false
+  password_wo = "something"
+  password_wo_version = 2`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccUserExists("semaphoreui_user.test"),
+					resource.TestCheckResourceAttr("semaphoreui_user.test", "username", fmt.Sprintf("test-%s", userNameSuffix)),
+					resource.TestCheckResourceAttr("semaphoreui_user.test", "password_wo_version", "2"),
+					resource.TestCheckNoResourceAttr("semaphoreui_user.test", "password_wo"),
+					resource.TestCheckNoResourceAttr("semaphoreui_user.test", "password"),
+					resource.TestCheckResourceAttr("semaphoreui_user.test", "admin", "false"),
+				),
 			},
 		},
 	})

--- a/internal/provider/user_schema.go
+++ b/internal/provider/user_schema.go
@@ -165,7 +165,7 @@ func userSchema() superschema.Schema {
 			"password_wo_version": superschema.Int64Attribute{
 				Common: &schemaR.Int64Attribute{
 					Optional:    true,
-					Description: "Version tracker to trigger updates for the password write-only attribute.",
+					Description: "Version tracker to trigger updates for the write-only password attribute.",
 				},
 				Resource: &schemaR.Int64Attribute{
 					Optional: true,

--- a/internal/provider/user_schema.go
+++ b/internal/provider/user_schema.go
@@ -17,15 +17,17 @@ import (
 )
 
 type UserModel struct {
-	ID       types.Int64  `tfsdk:"id"`
-	Created  types.String `tfsdk:"created"`
-	Username types.String `tfsdk:"username"`
-	Name     types.String `tfsdk:"name"`
-	Email    types.String `tfsdk:"email"`
-	Admin    types.Bool   `tfsdk:"admin"`
-	External types.Bool   `tfsdk:"external"`
-	Alert    types.Bool   `tfsdk:"alert"`
-	Password types.String `tfsdk:"password"`
+	ID                types.Int64  `tfsdk:"id"`
+	Created           types.String `tfsdk:"created"`
+	Username          types.String `tfsdk:"username"`
+	Name              types.String `tfsdk:"name"`
+	Email             types.String `tfsdk:"email"`
+	Admin             types.Bool   `tfsdk:"admin"`
+	External          types.Bool   `tfsdk:"external"`
+	Alert             types.Bool   `tfsdk:"alert"`
+	Password          types.String `tfsdk:"password"`
+	PasswordWO        types.String `tfsdk:"password_wo"`
+	PasswordWOVersion types.Int64  `tfsdk:"password_wo_version"`
 }
 
 func userSchema() superschema.Schema {
@@ -133,10 +135,46 @@ func userSchema() superschema.Schema {
 					PlanModifiers: []planmodifier.String{
 						stringplanmodifier.UseStateForUnknown(),
 					},
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(path.MatchRoot("password_wo")),
+					},
 				},
 				DataSource: &schemaD.StringAttribute{
 					MarkdownDescription: "This value is never returned by the API and will be an empty string.",
 					Computed:            true,
+				},
+			},
+			"password_wo": superschema.StringAttribute{
+				Common: &schemaR.StringAttribute{
+					Sensitive: true,
+					WriteOnly: true,
+				},
+				Resource: &schemaR.StringAttribute{
+					MarkdownDescription: "Login Password. Write-only version for ephemeral compatibility.",
+					Optional:            true,
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(path.MatchRoot("password")),
+						stringvalidator.AlsoRequires(path.MatchRoot("password_wo_version")),
+					},
+				},
+				DataSource: &schemaD.StringAttribute{
+					MarkdownDescription: "This value is never returned by the API and will be an empty string.",
+					Computed:            true,
+				},
+			},
+			"password_wo_version": superschema.Int64Attribute{
+				Common: &schemaR.Int64Attribute{
+					Optional:    true,
+					Description: "Version tracker to trigger updates for the password write-only attribute.",
+				},
+				Resource: &schemaR.Int64Attribute{
+					Optional: true,
+					Validators: []validator.Int64{
+						int64validator.AlsoRequires(path.MatchRoot("password_wo")),
+					},
+				},
+				DataSource: &schemaD.Int64Attribute{
+					Computed: true,
 				},
 			},
 			"admin": superschema.BoolAttribute{


### PR DESCRIPTION
Hi,

This PR adds support for write-only attributes that were added in terraform/opentofu v1.11.0.

The following attributes now have a write-only counterpart:
* `semaphoreui_project_key.login_password.password` -> `semaphoreui_project_key.login_password.password_wo`
* `semaphoreui_project_key.ssh.passphrase` -> `semaphoreui_project_key.ssh.passphrase_wo`
* `semaphoreui_project_key.ssh.private_key` -> `semaphoreui_project_key.ssh.private_key_wo`
* `semaphoreui_user.password` -> `semaphoreui_user.password_wo`

To trigger a change for one of the write-only attributes, there is an additional `wo_version` attribute for each new write-only attribute, to track if an update is necessary. This was implemented according to the [best practices](https://developer.hashicorp.com/terraform/plugin/framework/resources/write-only-arguments#best-practices) from hashicorp.

This PR supersedes #14 