### PR TITLE
fix(template): defer playbook validator when app/playbook are unknown

### DIFF
--- a/internal/provider/project_template_resource.go
+++ b/internal/provider/project_template_resource.go
@@ -57,6 +57,12 @@ func (r *projectTemplateResource) Schema(ctx context.Context, _ resource.SchemaR
 // require it. SemaphoreUI accepts an empty playbook only for `terraform` and
 // `tofu` apps; for everything else (ansible, bash, powershell, python, …) the
 // API returns 400 "template playbook can not be empty". See issue #26.
+//
+// The validator runs during ValidateConfig, which executes once per resource
+// block before for_each/count expansion. When `app` and/or `playbook` depend
+// on `each.value`/`count.index` they appear as Unknown here; in that case the
+// check is deferred to per-instance plan-time validation, where the values
+// will be known.
 type playbookRequiredValidator struct{}
 
 func (v playbookRequiredValidator) Description(_ context.Context) string {
@@ -73,11 +79,16 @@ func (v playbookRequiredValidator) ValidateResource(ctx context.Context, req res
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if !data.Playbook.IsNull() && !data.Playbook.IsUnknown() && data.Playbook.ValueString() != "" {
+	// Defer to per-instance validation when either value isn't known yet
+	// (e.g. the resource uses for_each/count referencing dynamic data).
+	if data.Playbook.IsUnknown() || data.App.IsUnknown() {
+		return
+	}
+	if !data.Playbook.IsNull() && data.Playbook.ValueString() != "" {
 		return
 	}
 	app := data.App.ValueString()
-	if data.App.IsNull() || data.App.IsUnknown() {
+	if data.App.IsNull() {
 		app = "ansible" // matches the schema default
 	}
 	if app == "terraform" || app == "tofu" {


### PR DESCRIPTION
### Summary

`playbookRequiredValidator` runs in `ValidateConfig`, which is invoked **once per resource block, before `for_each`/`count` expansion**. When `app` and/or `playbook` are derived from `each.value`/`count.index`, they are `Unknown` at this point. The previous logic:

- Coerced an `Unknown` `app` to the schema default `"ansible"`.
- But left an `Unknown` `playbook` to fail the "non-null, non-unknown, non-empty" guard.

Together this produced a false-positive `Missing playbook` error for configurations that are perfectly valid at apply time, e.g.:

```hcl
resource "semaphoreui_project_template" "all" {
  for_each = local.repos
  app      = each.value.content          # "terraform" or "ansible"
  playbook = each.value.content == "ansible" ? "main.yaml" : null
  # ...
}
```

Reported in #23.

### Fix

Defer validation when either `Playbook` or `App` is `Unknown`. The same `ConfigValidator` will run again per instance at plan time once values are resolved, so genuine misconfigurations are still caught — just not on the pre-expansion pass.

```go
if data.Playbook.IsUnknown() || data.App.IsUnknown() {
    return
}
```

The redundant `IsUnknown` checks further down were dropped since they are now unreachable.

### Why "skip on Unknown" and not "stricter check"

The alternative would be an attribute-level validator on `playbook` that uses `path.MatchRoot("app")` and reads the sibling value, so we could give a sharper error on the bare resource address. But:

1. The current behaviour already validates at plan time per instance (with the correct address like `["foo"]`), so coverage isn't lost.
2. "Skip on Unknown" matches the convention used by the upstream `terraform-plugin-framework` validators and most other community providers.
3. It's a one-line change.

Happy to take the stricter route in a follow-up if maintainers prefer.

### Testing

- `go build ./...` ✔
- `go vet ./...` ✔
- `gofmt -l .` clean ✔
- Manual: reproduced the original error against the user's Terraform config; the patched provider now passes `terraform validate` and `terraform plan`.

I did not add an acceptance test because the existing tests in `project_template_resource_test.go` are integration tests requiring a live SemaphoreUI server, and the `for_each`-with-`each.value` scenario is awkward to wire up there. A pure unit test for the validator would need scaffolding that doesn't exist in the repo today; I can add one in a follow-up if desired.

### Linked issue

Fixes #23
